### PR TITLE
Update 02-gke-setup.md

### DIFF
--- a/docs/istio/02-gke-setup.md
+++ b/docs/istio/02-gke-setup.md
@@ -4,7 +4,7 @@ Create a cluster with three nodes using the latest Kubernetes version:
 
 ```bash
 k8s_version=$(gcloud container get-server-config --format=json \
-| jq -r '.validNodeVersions[0]')
+| jq -r '.validMasterVersions[0]')
 
 gcloud container clusters create istio \
 --cluster-version=${k8s_version} \


### PR DESCRIPTION
Using `validNodeVersions` creates the following error: `ERROR: (gcloud.container.clusters.create) ResponseError: code=400, message=Master version "1.14.3-gke.9" is unsupported.` 
Using `validMasterVersions` prevents this.