### PR TITLE
Update nats mtls exclusion rule namespace

### DIFF
--- a/docs/openfaas/01-mtls-config.md
+++ b/docs/openfaas/01-mtls-config.md
@@ -46,7 +46,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
 metadata:
     name: "nats-no-mtls"
-    namespace: {{ .Release.Namespace }}
+    namespace: openfaas
 spec:
     host: "nats.openfaas.svc.cluster.local"
     trafficPolicy:


### PR DESCRIPTION
Fixes #12 - template in namespace that caused apply to fail.